### PR TITLE
Add code location to most code tokens

### DIFF
--- a/src/compiler/anylize/mod.rs
+++ b/src/compiler/anylize/mod.rs
@@ -22,10 +22,14 @@ pub enum AnylizeWarning {
 
 impl Display for AnylizeWarning {
   fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-    match self {
-      Self::NameShouldBeCamelCase => write!(f, "Name should be in camel case"),
-      Self::NameShouldBeSnakeCase => write!(f, "Name should be in snake case"),
-    }
+    write!(
+      f,
+      "Name should be in {}",
+      match self {
+        Self::NameShouldBeCamelCase => "camel case",
+        Self::NameShouldBeSnakeCase => "snake case",
+      }
+    )
   }
 }
 

--- a/src/compiler/errors.rs
+++ b/src/compiler/errors.rs
@@ -43,7 +43,7 @@ impl LocationError {
         }
 
         let mut spacing = String::from("");
-        for _ in 0..x + y.to_string().len() + format!("{}", y).len() + 1 {
+        for _ in 0..x + y.to_string().len() + 1 {
           spacing += " ";
         }
         output.push(format!(

--- a/src/compiler/files.rs
+++ b/src/compiler/files.rs
@@ -1,4 +1,4 @@
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct CodeLocation {
   pub file_name: Option<String>,
   pub x: Option<usize>,
@@ -13,11 +13,18 @@ impl CodeLocation {
       y: None,
     }
   }
-  pub fn only_file_name(file_name: Option<String>) -> Self {
+  pub fn only_file_name(file_name: String) -> Self {
     Self {
-      file_name,
+      file_name: Some(file_name),
       x: None,
       y: None,
+    }
+  }
+  pub fn only_location(x: usize, y: usize) -> Self {
+    Self {
+      file_name: None,
+      x: Some(x),
+      y: Some(y),
     }
   }
 }

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -78,7 +78,7 @@ impl Compiler {
 
     if c.options.debug {
       props.debug_formatted_tokens(
-        CodeLocation::only_file_name(Some(file_name.into())),
+        CodeLocation::only_file_name(file_name.into()),
         formatted_res.clone(),
       );
     }

--- a/src/compiler/target/javascript/mod.rs
+++ b/src/compiler/target/javascript/mod.rs
@@ -48,26 +48,26 @@ impl JavaScript {
   }
   pub fn action(&mut self, action: Action, lb: &mut impl BuildItems, inline: bool) {
     // match an action and return code
-    match action {
-      Action::Assigment(res) if inline => {
+    match action.type_ {
+      ActionType::Assigment(res) if inline => {
         lb.code(res.name + " = ");
         self.action(*res.action, lb, true);
       }
-      Action::Assigment(res) => {
+      ActionType::Assigment(res) => {
         let mut inline = Inline::from_str(res.name + " = ");
         self.action(*res.action, &mut inline, true);
       }
-      Action::Break => lb.code(if inline { "break" } else { "break;" }),
-      Action::Continue => lb.code(if inline { "continue" } else { "continue;" }),
-      Action::For(res) => self.action_for(res, lb),
-      Action::FunctionCall(res) => self.action_func_call(res, lb, inline),
-      Action::Loop(res) => self.action_loop(res, lb),
-      Action::Return(res) => self.action_return(res, lb),
-      Action::StaticNumber(res) => self.action_num(res, lb),
-      Action::StaticString(res) => self.action_str(res, lb),
-      Action::Variable(res) => self.action_var(res, lb),
-      Action::VarRef(res) => lb.code(res + if inline { "" } else { ";" }),
-      Action::While(res) => self.action_while(res, lb),
+      ActionType::Break => lb.code(if inline { "break" } else { "break;" }),
+      ActionType::Continue => lb.code(if inline { "continue" } else { "continue;" }),
+      ActionType::For(res) => self.action_for(res, lb),
+      ActionType::FunctionCall(res) => self.action_func_call(res, lb, inline),
+      ActionType::Loop(res) => self.action_loop(res, lb),
+      ActionType::Return(res) => self.action_return(res, lb),
+      ActionType::StaticNumber(res) => self.action_num(res, lb),
+      ActionType::StaticString(res) => self.action_str(res, lb),
+      ActionType::Variable(res) => self.action_var(res, lb),
+      ActionType::VarRef(res) => lb.code(res + if inline { "" } else { ";" }),
+      ActionType::While(res) => self.action_while(res, lb),
     };
   }
   pub fn action_for(&mut self, action: ActionFor, lb: &mut impl BuildItems) {
@@ -119,10 +119,10 @@ impl JavaScript {
 
     lb.inline(src);
   }
-  pub fn action_num(&mut self, action: Number, lb: &mut impl BuildItems) {
-    lb.code(match action {
-      Number::Float(res) => res.to_string(),
-      Number::Int(res) => res.to_string(),
+  pub fn action_num(&mut self, number: Number, lb: &mut impl BuildItems) {
+    lb.code(match number.type_ {
+      NumberType::Float(res) => res.to_string(),
+      NumberType::Int(res) => res.to_string(),
     });
   }
   pub fn action_str(&mut self, action: String_, lb: &mut impl BuildItems) {

--- a/src/compiler/target/mod.rs
+++ b/src/compiler/target/mod.rs
@@ -6,8 +6,8 @@ pub use anylize::AnilizedTokens;
 pub use builder::{Block, BuildItems, Inline, LangBuilder};
 use javascript::JavaScript;
 pub use tokenize::{
-  Action, ActionFor, ActionFunctionCall, Actions, Enum, Function, GlobalType, Number, String_,
-  Struct, VarType, Variable,
+  Action, ActionFor, ActionFunctionCall, ActionType, Actions, Enum, Function, GlobalType, Number,
+  NumberType, String_, Struct, VarType, Variable,
 };
 
 #[derive(Clone)]

--- a/src/compiler/tokenize/function.rs
+++ b/src/compiler/tokenize/function.rs
@@ -1,11 +1,13 @@
 use super::*;
 use actions::ParseActions;
 use errors::{LocationError, TokenizeError};
+use files::CodeLocation;
 use statics::{valid_name_char, NameBuilder};
 use types::parse_type;
 
 #[derive(Debug, Clone)]
 pub struct Function {
+  pub location: CodeLocation,
   pub name: Option<String>,
   pub args: Vec<(String, Type)>,
   pub res: Option<Type>,
@@ -13,6 +15,8 @@ pub struct Function {
 }
 
 pub fn parse_function(t: &mut Tokenizer, anonymous: bool) -> Result<Function, LocationError> {
+  let location = t.last_index_location();
+
   // Parse the function name
   let mut name_builder: Option<NameBuilder> = None;
   loop {
@@ -112,6 +116,7 @@ pub fn parse_function(t: &mut Tokenizer, anonymous: bool) -> Result<Function, Lo
   let body = ParseActions::start(t)?;
 
   Ok(Function {
+    location,
     name,
     args,
     res,

--- a/src/compiler/tokenize/mod.rs
+++ b/src/compiler/tokenize/mod.rs
@@ -11,11 +11,11 @@ pub mod variable;
 
 use super::errors;
 use super::files;
-pub use action::{Action, ActionAssigment, ActionFor, ActionFunctionCall, ActionWhile};
+pub use action::{Action, ActionAssigment, ActionFor, ActionFunctionCall, ActionType, ActionWhile};
 pub use actions::Actions;
 pub use function::Function;
 pub use globals::{DataType, Tokenizer};
-pub use numbers::Number;
+pub use numbers::{Number, NumberType};
 pub use statics::Keywords;
 pub use strings::String_;
 pub use types::{Enum, GlobalType, Struct, Type};

--- a/src/compiler/tokenize/strings.rs
+++ b/src/compiler/tokenize/strings.rs
@@ -1,19 +1,22 @@
 use super::*;
 use errors::LocationError;
+use files::CodeLocation;
 
 #[derive(Debug, Clone)]
 pub struct String_ {
+  pub location: CodeLocation,
   pub content: String,
 }
 
-impl Into<Action> for String_ {
-  fn into(self) -> Action {
-    Action::StaticString(self)
+impl Into<ActionType> for String_ {
+  fn into(self) -> ActionType {
+    ActionType::StaticString(self)
   }
 }
 
 pub fn parse_static_str<'a>(t: &'a mut Tokenizer) -> Result<String_, LocationError> {
   let mut res = String_ {
+    location: t.last_index_location(),
     content: String::new(),
   };
   let mut string_content: Vec<u8> = vec![];

--- a/src/compiler/tokenize/variable.rs
+++ b/src/compiler/tokenize/variable.rs
@@ -1,6 +1,7 @@
 use super::*;
 use action::{ActionToExpect, ParseAction};
 use errors::LocationError;
+use files::CodeLocation;
 use statics::{valid_name_char, NameBuilder};
 use types::parse_type;
 
@@ -16,11 +17,12 @@ pub struct Variable {
   pub data_type: Option<Type>,
   pub name: String,
   pub action: Box<Action>,
+  pub location: CodeLocation,
 }
 
-impl Into<Action> for Variable {
-  fn into(self) -> Action {
-    Action::Variable(self)
+impl Into<ActionType> for Variable {
+  fn into(self) -> ActionType {
+    ActionType::Variable(self)
   }
 }
 
@@ -28,6 +30,7 @@ pub fn parse_var<'a>(
   t: &'a mut Tokenizer,
   var_type_option: Option<VarType>,
 ) -> Result<Variable, LocationError> {
+  let location = t.last_index_location();
   let mut name = NameBuilder::new();
   let mut data_type: Option<Type> = None;
 
@@ -79,6 +82,7 @@ pub fn parse_var<'a>(
   let action = ParseAction::start(t, false, ActionToExpect::Assignment(""))?;
 
   Ok(Variable {
+    location,
     var_type,
     data_type,
     name: name.to_string(t)?,


### PR DESCRIPTION
This adds locations to most generated tokens, for example variables, actions, types, etc..  
This hasn't much use currently but we can later use this in stage 2 to show the location of an error / warning.  

This reduces the compile speed probably quite a bit because we now need the x and y a lot more often than before.  
There are probably ways to keep track of the x and y much more efficient but haven't thought about it to much yet.  
I'll probably re-write this hole thing one day but that takes a lot more time so doing that another day :).