### PR TITLE
Fix for loop item name

### DIFF
--- a/src/compiler/tokenize/action.rs
+++ b/src/compiler/tokenize/action.rs
@@ -445,6 +445,7 @@ impl<'a> ParseAction<'a> {
         ActionToExpect::Assignment("{"),
       )?),
       LoopType::For => {
+        self.t.index -= 1;
         let mut name = NameBuilder::new();
         loop {
           match self.t.must_next_char()? {


### PR DESCRIPTION
Quick fix for an issue where the `for` loop did not include the first character of the `item` name.